### PR TITLE
scripts.js comma fixes

### DIFF
--- a/src/SourceIndexServer/scripts.js
+++ b/src/SourceIndexServer/scripts.js
@@ -108,9 +108,10 @@ function processHash() {
                 specialAnchorType = hashParts.pop();
                 entireAnchorIsFile = false;
             }
-            var lastPart = hashParts[hashParts.length - 1];
-            // match a line number (any number of decimal digits) or a hash (16 hex digits)
-            if (lastPart.match(/^[0-9]+$/) || lastPart.match(/^[0-9a-f]{16}$/)) {
+            lastPart = hashParts[hashParts.length - 1];
+            var lineNumberRegex = new RegExp("^\\d+$");
+            var hashRegex = new RegExp("^[0-9a-f]{16}$")
+            if (lineNumberRegex.test(lastPart) || hashRegex.test(lastPart)) {
                 hashOrLine = hashParts.pop();
                 entireAnchorIsFile = false;
             }
@@ -660,11 +661,9 @@ function redirect(map, prefixLength) {
         anchor = anchor.slice(1);
         var hashParts = anchor.split(anchorSplitChar);
         var anchorHasReferencesSuffix = false;
-        if (hashParts.length > 1) {
-            if (hashParts[hashParts.length - 1] == "references") {
-                anchorHasReferencesSuffix = true;
-                hashParts.pop();
-            }
+        if (hashParts.length > 1 && hashParts[hashParts.length - 1] == "references") {
+            anchorHasReferencesSuffix = true;
+            hashParts.pop();
         }
         var id = hashParts.join(anchorSplitChar);
         var shortId = id;
@@ -695,11 +694,9 @@ function redirectToNextLevelRedirectFile() {
         anchor = anchor.slice(1);
         var hashParts = anchor.split(anchorSplitChar);
         var anchorHasReferencesSuffix = false;
-        if (hashParts.length > 1) {
-            if (hashParts[hashParts.length - 1] == "references") {
-                anchorHasReferencesSuffix = true;
-                hashParts.pop();
-            }
+        if (hashParts.length > 1 && hashParts[hashParts.length - 1] == "references") {
+            anchorHasReferencesSuffix = true;
+            hashParts.pop();
         }
         var id = hashParts.join(anchorSplitChar);
 

--- a/src/SourceIndexServer/scripts.js
+++ b/src/SourceIndexServer/scripts.js
@@ -92,14 +92,6 @@ function processHash() {
             return;
         }
 
-        while (anchor.indexOf("%2C") != -1) {
-            anchor = anchor.replace("%2C", ",");
-        }
-
-        while (anchor.indexOf("%2c") != -1) {
-            anchor = anchor.replace("%2c", ",");
-        }
-
         var hashParts = anchor.split(anchorSplitChar);
         if (anchor.indexOf(anchorSplitChar) == -1 && anchor.indexOf("#") > -1) {
             // keep old URLs working for compat

--- a/src/SourceIndexServer/scripts.js
+++ b/src/SourceIndexServer/scripts.js
@@ -99,8 +99,22 @@ function processHash() {
         }
 
         var potentialFile = anchor;
+        var entireAnchorIsFile = true;
+        var specialAnchorType = "";
+        var hashOrLine = "";
         if (hashParts.length > 1) {
-            potentialFile = hashParts[0];
+            var lastPart = hashParts[hashParts.length - 1];
+            if (lastPart == "references" || lastPart == "namespaces") {
+                specialAnchorType = hashParts.pop();
+                entireAnchorIsFile = false;
+            }
+            var lastPart = hashParts[hashParts.length - 1];
+            // match a line number (any number of decimal digits) or a hash (16 hex digits)
+            if (lastPart.match(/^[0-9]+$/) || lastPart.match(/^[0-9a-f]{16}$/)) {
+                hashOrLine = hashParts.pop();
+                entireAnchorIsFile = false;
+            }
+            potentialFile = hashParts.join(anchorSplitChar);
         }
 
         potentialFile = decodeURIComponent(potentialFile);
@@ -120,16 +134,16 @@ function processHash() {
                 fileUrl = fileUrl + ".html";
             }
 
-            if (hashParts.length > 1) {
-                fileUrl = fileUrl + "#" + createSafeLineNumber(hashParts[1]);
+            if (hashOrLine) {
+                fileUrl = fileUrl + "#" + createSafeLineNumber(hashOrLine);
             }
 
             redirectLocation(s, fileUrl);
 
             var pathParts = potentialFile.split("/");
             if (pathParts.length > 1) {
-                if (hashParts.length == 3 && hashParts[2] == "references") {
-                    redirectLocation(n, "/" + pathParts[0] + "/R/" + hashParts[1] + ".html");
+                if (specialAnchorType == "references") {
+                    redirectLocation(n, "/" + pathParts[0] + "/R/" + hashOrLine + ".html");
                 }
                 else {
                     if (pathParts[0] != "MSBuildFiles" && pathParts[0] != "TypeScriptFiles") {
@@ -137,9 +151,9 @@ function processHash() {
                     }
                 }
             }
-        } else if (hashParts.length == 1 && potentialFile.indexOf("/") == -1) {
+        } else if (entireAnchorIsFile && potentialFile.indexOf("/") == -1) {
             redirectLocation(n, "/" + potentialFile + "/ProjectExplorer.html");
-        } else if (hashParts.length == 2 && potentialFile.indexOf("/") == -1 && hashParts[1] == "namespaces") {
+        } else if (specialAnchorType == "namespaces" && potentialFile.indexOf("/") == -1) {
             redirectLocation(n, "/" + potentialFile + "/namespaces.html");
         }
     } else if (useSolutionExplorer) {
@@ -645,7 +659,14 @@ function redirect(map, prefixLength) {
     if (anchor) {
         anchor = anchor.slice(1);
         var hashParts = anchor.split(anchorSplitChar);
-        var id = hashParts[0];
+        var anchorHasReferencesSuffix = false;
+        if (hashParts.length > 1) {
+            if (hashParts[hashParts.length - 1] == "references") {
+                anchorHasReferencesSuffix = true;
+                hashParts.pop();
+            }
+        }
+        var id = hashParts.join(anchorSplitChar);
         var shortId = id;
         if (prefixLength < shortId.length) {
             shortId = shortId.slice(0, prefixLength);
@@ -658,7 +679,7 @@ function redirect(map, prefixLength) {
         var redirectTo = map[shortId];
         if (redirectTo) {
             var destination = redirectTo + ".html" + "#" + createSafeLineNumber(id);
-            if (hashParts.length == 2) {
+            if (anchorHasReferencesSuffix) {
                 destination = destination + anchorSplitChar + "references";
             }
 
@@ -673,10 +694,17 @@ function redirectToNextLevelRedirectFile() {
     if (anchor) {
         anchor = anchor.slice(1);
         var hashParts = anchor.split(anchorSplitChar);
-        var id = hashParts[0];
+        var anchorHasReferencesSuffix = false;
+        if (hashParts.length > 1) {
+            if (hashParts[hashParts.length - 1] == "references") {
+                anchorHasReferencesSuffix = true;
+                hashParts.pop();
+            }
+        }
+        var id = hashParts.join(anchorSplitChar);
 
         var destination = "a" + id.slice(0, 1) + ".html" + "#" + createSafeLineNumber(id);
-        if (hashParts.length == 2) {
+        if (anchorHasReferencesSuffix) {
             destination = destination + anchorSplitChar + "references";
         }
 


### PR DESCRIPTION
The "anchorSplitChar" is used to separate the elements of the URL between the filename, the hash or line number if present, and the type of search (namespaces, references, or neither) if present. Currently this character is the comma. Unfortunately comma is a permissible character in filenames as well; in fact, a comma exists in a filename in the test solution (https://github.com/KirillOsenkov/SourceBrowser/blob/master/TestCode/Project2/-._%7E!%24'()%2B%2C%3D%40.cs), so splitting on comma alone is not safe as it results in "filenames" that are missing any text after the comma.

Three solutions come to mind:
- Change the split character to something else, for example a URL-safe character that is not usually allowed in filenames, like `*`. This would require finding all the relevant places literal commas are hard-coded and seemed error-prone, and would also (debatably) make the URL's less human-readable.
- Change all the places that generate the URL's to encode commas in filenames. After some investigation of this option, finding and fixing all of those seemed more complex than the third alternative.
- Change the places that parse the URL's to use the context around the comma to understand if it's an element-splitting comma or part of a filename. That's what I've done in this commit.